### PR TITLE
Implement TestHelper.TestMacro.examples/2 macro

### DIFF
--- a/apps/anoma_client/test/client_test.exs
+++ b/apps/anoma_client/test/client_test.exs
@@ -1,17 +1,6 @@
 defmodule Anoma.ClientTest do
   use ExUnit.Case
 
-  alias Anoma.Client.Examples.EClient
-
-  excluded = []
-
-  EClient.__info__(:functions)
-  |> Enum.filter(fn {func, arity} ->
-    func not in excluded and arity == 0
-  end)
-  |> Enum.map(fn {func, _arity} ->
-    test "#{func}" do
-      apply(EClient, unquote(func), [])
-    end
-  end)
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Client.Examples.EClient
 end

--- a/apps/anoma_client/test/proxy_test.exs
+++ b/apps/anoma_client/test/proxy_test.exs
@@ -1,17 +1,7 @@
 defmodule ProxyTest do
   use ExUnit.Case
 
-  alias Anoma.Client.Examples.EProxy
-
-  excluded = [:start_proxy_for, :__struct__]
-
-  EProxy.__info__(:functions)
-  |> Enum.filter(fn {func, arity} ->
-    func not in excluded and arity == 0
-  end)
-  |> Enum.map(fn {func, _arity} ->
-    test "#{func}" do
-      apply(EProxy, unquote(func), [])
-    end
-  end)
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Client.Examples.EProxy,
+    skip: [:start_proxy_for]
 end

--- a/apps/anoma_lib/lib/test_helper/generate_example_tests.ex
+++ b/apps/anoma_lib/lib/test_helper/generate_example_tests.ex
@@ -1,0 +1,98 @@
+defmodule TestHelper.GenerateExampleTests do
+  @moduledoc """
+  I generate test cases for all public functions with arity 0 from the given module.
+
+  This macro inspects the given `module` at compile time, retrieves all its public
+  functions with arity 0 (excluding any functions specified in the `:skip` option
+  and the `__struct__/0` function), and generates a test case for each one.
+
+  ### Usage
+
+  ```elixir
+  use TestHelper.GenerateExampleTests, for: EMyModule, skip: [:func1, :func2]
+  ```
+
+  ### Options
+
+  - `:for` - (Required) The module from which to retrieve the public functions.
+  - `:skip` - (Optional) A list of function names (as atoms) to exclude from the generated tests.
+
+  ### Notes
+
+  - If a function specified in `:skip` is not a public function with arity 0 in the module,
+    a compile-time error is raised.
+
+  """
+
+  @excluded_functions [:__struct__]
+
+  defmacro __using__(opts) do
+    module = extract_module(opts, __CALLER__)
+    skip_functions = extract_skip_functions(opts)
+    functions = extract_module_functions(module, skip_functions)
+
+    tests =
+      for func <- functions do
+        test_name = "example #{inspect(module)}.#{func}/0"
+
+        quote do
+          test unquote(test_name) do
+            unquote(module).unquote(func)()
+          end
+        end
+      end
+
+    quote do
+      (unquote_splicing(tests))
+    end
+  end
+
+  defp extract_module(opts, caller) do
+    module = Keyword.fetch!(opts, :for)
+    module = Macro.expand(module, caller)
+
+    if not is_atom(module) do
+      raise ArgumentError,
+            "Expected :for option to be an atom, got: #{inspect(module)}"
+    end
+
+    if not Code.ensure_loaded?(module) do
+      raise ArgumentError, "Module #{inspect(module)} is not loaded"
+    end
+
+    module
+  end
+
+  defp extract_skip_functions(opts) do
+    skip_functions = Keyword.get(opts, :skip, [])
+
+    if not (is_list(skip_functions) and Enum.all?(skip_functions, &is_atom/1)) do
+      raise ArgumentError, ":skip option must be a list of atoms"
+    end
+
+    skip_functions
+  end
+
+  defp extract_module_functions(module, skip_functions) do
+    module_functions = get_module_functions(module)
+    validate_skip_functions(skip_functions, module_functions, module)
+    module_functions -- skip_functions
+  end
+
+  defp get_module_functions(module) do
+    module.__info__(:functions)
+    |> Enum.filter(fn {func, arity} ->
+      arity == 0 and func not in @excluded_functions
+    end)
+    |> Enum.map(fn {func, _arity} -> func end)
+  end
+
+  defp validate_skip_functions(skip_functions, module_functions, module) do
+    undefined_functions = skip_functions -- module_functions
+
+    if undefined_functions != [] do
+      raise ArgumentError,
+            "Cannot skip undefined functions: #{inspect(undefined_functions)} in module #{inspect(module)}"
+    end
+  end
+end

--- a/apps/anoma_lib/test/commitment_tree_test.exs
+++ b/apps/anoma_lib/test/commitment_tree_test.exs
@@ -1,17 +1,12 @@
 defmodule CommitmentTreeTest do
   alias Examples.ECommitmentTree
-  use TestHelper.TestMacro
-  doctest CommitmentTree
 
-  test "sha256 examples" do
-    ECommitmentTree.sha256_32_spec()
-    ECommitmentTree.memory_backed_ct()
-    ECommitmentTree.empty_mnesia_backed_ct()
-    ECommitmentTree.current_tree_mnesia_ct()
-    ECommitmentTree.babylon_mnesia_ct()
-    ECommitmentTree.current_tree_mnesia_ct()
-    ECommitmentTree.lots_of_inserts_ct()
-  end
+  use TestHelper.TestMacro
+
+  use TestHelper.GenerateExampleTests,
+    for: ECommitmentTree
+
+  doctest CommitmentTree
 
   test "cairo poseidon examples" do
     cairo_spec = ECommitmentTree.cairo_poseidon_spec()

--- a/apps/anoma_lib/test/crypto_test.exs
+++ b/apps/anoma_lib/test/crypto_test.exs
@@ -1,14 +1,6 @@
 defmodule AnomaTest.Crypto do
   use ExUnit.Case, async: true
-
-  alias Examples.ECrypto
+  use TestHelper.GenerateExampleTests, for: Examples.ECrypto
 
   doctest(Anoma.Crypto.Id)
-
-  test "examples" do
-    ECrypto.xcc()
-    ECrypto.londo()
-    ECrypto.blood_l_signed_detached()
-    ECrypto.blood_l_signed()
-  end
 end

--- a/apps/anoma_lib/test/nock_test.exs
+++ b/apps/anoma_lib/test/nock_test.exs
@@ -1,41 +1,8 @@
 defmodule AnomaTest.Nock do
   use TestHelper.TestMacro, async: true
-
-  alias Examples.ENock
+  use TestHelper.GenerateExampleTests, for: Examples.ENock
 
   doctest(Nock)
   doctest(Noun)
   doctest(Noun.Format)
-
-  test "examples" do
-    ENock.dec()
-    ENock.factorial()
-    ENock.sign_detatched()
-    ENock.verify_detatched()
-    ENock.sign()
-    ENock.verify()
-    ENock.bex()
-    ENock.mix()
-    ENock.shax()
-    ENock.met0()
-    ENock.met1()
-    ENock.met2()
-    ENock.lsh0()
-    ENock.lsh1()
-    ENock.lsh2()
-    ENock.rsh0()
-    ENock.rsh1()
-    ENock.rsh2()
-    ENock.uend0()
-    ENock.uend1()
-    ENock.raw_27_4()
-    # Next one calls this... so uneeded but who cares
-    ENock.jamming_and_cueing()
-    ENock.one_two()
-    ENock.nesting_noun()
-    ENock.incorrectly_ending()
-    ENock.incorrectly_starting()
-    ENock.indexed_noun()
-    ENock.replacing_terms()
-  end
 end

--- a/apps/anoma_node/lib/examples/e_logging.ex
+++ b/apps/anoma_node/lib/examples/e_logging.ex
@@ -18,6 +18,10 @@ defmodule Anoma.Node.Examples.ELogging do
     # Logging.start_link(node_id: "londo_mollari")
   end
 
+  ############################################################
+  #                     Transaction event                    #
+  ############################################################
+
   def check_tx_event(
         node_id \\ ("londo_mollari" <> :crypto.strong_rand_bytes(16))
         |> Base.url_encode64()
@@ -80,6 +84,10 @@ defmodule Anoma.Node.Examples.ELogging do
     :mnesia.unsubscribe({:table, table_name, :simple})
   end
 
+  ############################################################
+  #                      Consensus event                     #
+  ############################################################
+
   def check_consensus_event(
         node_id \\ ("londo_mollari" <> :crypto.strong_rand_bytes(16))
         |> Base.url_encode64()
@@ -130,6 +138,10 @@ defmodule Anoma.Node.Examples.ELogging do
                :mnesia.read(table_name, :consensus)
              end)
   end
+
+  ############################################################
+  #                         Block event                      #
+  ############################################################
 
   def check_block_event(
         node_id \\ ("londo_mollari" <> :crypto.strong_rand_bytes(16))

--- a/apps/anoma_node/lib/examples/e_transaction.ex
+++ b/apps/anoma_node/lib/examples/e_transaction.ex
@@ -6,7 +6,9 @@ defmodule Anoma.Node.Examples.ETransaction do
 
   alias Anoma.Node.Registry
 
-  ## storage
+  ############################################################
+  #                          Storage                         #
+  ############################################################
 
   def restart_storage(node_id \\ "londo_mollari") do
     pid = Registry.whereis(node_id, Storage)
@@ -168,7 +170,10 @@ defmodule Anoma.Node.Examples.ETransaction do
     }
   end
 
-  ## ordering
+  ############################################################
+  #                         Ordering                         #
+  ############################################################
+
   def restart_ordering(node_id \\ "londo_mollari") do
     pid = Registry.whereis(node_id, Ordering)
 
@@ -270,6 +275,10 @@ defmodule Anoma.Node.Examples.ETransaction do
 
     {:debug_term_storage, inc}
   end
+
+  ############################################################
+  #                        Transactions                      #
+  ############################################################
 
   def zero_counter_submit(node_id \\ "londo_mollari") do
     key = "key"

--- a/apps/anoma_node/test/consensus_test.exs
+++ b/apps/anoma_node/test/consensus_test.exs
@@ -1,10 +1,4 @@
 defmodule ConsensusTest do
   use ExUnit.Case, async: false
-
-  alias Anoma.Node.Examples.EConsensus
-
-  test "consensus examples" do
-    EConsensus.startup_execution()
-    EConsensus.execution_continues()
-  end
+  use TestHelper.GenerateExampleTests, for: Anoma.Node.Examples.EConsensus
 end

--- a/apps/anoma_node/test/logging_test.exs
+++ b/apps/anoma_node/test/logging_test.exs
@@ -1,21 +1,6 @@
 defmodule LoggingTest do
   use ExUnit.Case, async: false
 
-  alias Anoma.Node.Examples.ELogging
-
-  test "transaction event examples" do
-    ELogging.check_tx_event()
-    ELogging.check_multiple_tx_events()
-  end
-
-  test "consensus event examples" do
-    ELogging.check_consensus_event()
-    ELogging.check_consensus_event_multiple()
-  end
-
-  test "block event examples" do
-    ELogging.check_block_event()
-    ELogging.check_block_event_multiple()
-    ELogging.check_block_event_leave_one_out()
-  end
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Node.Examples.ELogging
 end

--- a/apps/anoma_node/test/registry_test.exs
+++ b/apps/anoma_node/test/registry_test.exs
@@ -1,15 +1,4 @@
 defmodule Examples.RegistryTest do
   use TestHelper.TestMacro
-
-  alias Anoma.Node.Examples.ERegistry
-
-  test "registry tests" do
-    ERegistry.create_address()
-    ERegistry.create_address_with_label()
-    ERegistry.generate_name()
-    ERegistry.generate_name_with_label()
-    ERegistry.find_pid_of_process()
-    ERegistry.list_engines_for_node()
-    ERegistry.single_node_running()
-  end
+  use TestHelper.GenerateExampleTests, for: Anoma.Node.Examples.ERegistry
 end

--- a/apps/anoma_node/test/solver_test.exs
+++ b/apps/anoma_node/test/solver_test.exs
@@ -1,12 +1,12 @@
 defmodule SolverTest do
   use ExUnit.Case, async: false
 
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Node.Examples.ESolver
+
   alias Anoma.Node.Examples.{ESolver, ENode}
 
   test "intentpool examples" do
-    ESolver.solve_transaction()
-    ESolver.solve_transactions_with_remainder()
-
     ESolver.solvable_transaction_via_intent_pool(
       ENode.start_node(node_id: "S_test3")
     )

--- a/apps/anoma_node/test/tcp_test.exs
+++ b/apps/anoma_node/test/tcp_test.exs
@@ -1,10 +1,8 @@
 defmodule Examples.TcpTest do
   use TestHelper.TestMacro
+
+  use TestHelper.GenerateExampleTests,
+    for: Anoma.Node.Examples.ETransport.ETcp
+
   doctest CommitmentTree
-
-  alias Anoma.Node.Examples.ETransport.ETcp
-
-  test "tcp client and server examples" do
-    ETcp.connect_nodes()
-  end
 end

--- a/apps/anoma_node/test/transaction_test.exs
+++ b/apps/anoma_node/test/transaction_test.exs
@@ -1,39 +1,4 @@
 defmodule TransactionTest do
   use ExUnit.Case, async: true
-
-  alias Anoma.Node.Examples.ETransaction
-
-  test "storage examples" do
-    ETransaction.write_then_read()
-    ETransaction.write_then_read_other()
-    ETransaction.read_future_then_write()
-    ETransaction.read_future_then_write()
-    ETransaction.read_other_future_then_write()
-    ETransaction.write_future_then_write_present()
-    ETransaction.write_multiple_then_read()
-    ETransaction.write_future_multiple_then_write_present()
-    ETransaction.append_then_read()
-    ETransaction.append_then_read_same()
-    ETransaction.append_then_read_several()
-    ETransaction.append_twice_then_read()
-    ETransaction.append_twice_then_read_with_commit()
-    ETransaction.complicated_storage()
-    ETransaction.complicated_storage_with_commit()
-  end
-
-  test "ordering examples" do
-    ETransaction.ord_write_then_read()
-    ETransaction.ord_read_future_then_write()
-    ETransaction.ord_order_first()
-  end
-
-  test "transaction examples" do
-    ETransaction.zero_counter_submit()
-    ETransaction.inc_counter_submit_with_zero()
-    ETransaction.inc_counter_submit_after_zero()
-    ETransaction.inc_counter_submit_after_read()
-    ETransaction.bluf_transaction_errors()
-    ETransaction.read_txs_write_nothing()
-    ETransaction.bluff_txs_write_nothing()
-  end
+  use TestHelper.GenerateExampleTests, for: Anoma.Node.Examples.ETransaction
 end


### PR DESCRIPTION
While studying the documentation, I came across [an outstanding question](https://anoma.github.io/anoma/examples-over-testing.html#outstanding-questions) in the [Examples over Testing](https://anoma.github.io/anoma/examples-over-testing.html) chapter:

> How long until we have a macro that automatically registers examples so they can be run with [mix test](https://hexdocs.pm/mix/Mix.Tasks.Test.html)?

I thought this might be a good first task to work on, as it seems relatively straightforward and would help me get familiar with the codebase and the contribution process.

Please let me know your thoughts on this approach. I'm happy to adjust or expand on it if needed.